### PR TITLE
icons and text aligned in skills

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1141,6 +1141,8 @@ h2 {
   font-size: 40px;
   color: #0277bd;
   margin-bottom: 10px;
+  margin-right: 30px;
+
   display: block;
 }
 
@@ -1196,6 +1198,7 @@ h2 {
   font-size: 40px;
   color: #0277bd;
   margin-bottom: 10px;
+  margin-left: 30px;
 }
 
 .skill span {


### PR DESCRIPTION
### Description
non alignment of skill icon and skill name
### Changes Made
now the skill name and skill icon are centrally aligned
### Screenshots/Preview (if applicable)
![image](https://github.com/SnowScriptWinterOfCode/PortfolioCreations/assets/122210300/8ebe3f08-1126-4f56-a4d9-89c5290ec8fb)



